### PR TITLE
fix: expect less of kernel, sleep longer in tests

### DIFF
--- a/tests/100-lines.args
+++ b/tests/100-lines.args
@@ -1,1 +1,1 @@
--- sh -c 'for i in `seq 1 100`; do echo line $i to stdout; sleep 0; echo line $i to stderr 1>&2; sleep 0; done'
+-- sh -c 'for i in `seq 1 100`; do echo line $i to stdout; sleep 0.01; echo line $i to stderr 1>&2; sleep 0.01; done'

--- a/tests/15-factorial.args
+++ b/tests/15-factorial.args
@@ -1,1 +1,1 @@
--- sh -c 'for i in $(seq 1 15); do echo "line $i to stdout"; sleep 0; for j in $(seq 1 $i); do echo "line $j to stderr" 1>&2; sleep 0; done; done'
+-- sh -c 'for i in $(seq 1 15); do echo "line $i to stdout"; sleep 0.01; for j in $(seq 1 $i); do echo "line $j to stderr" 1>&2; sleep 0.01; done; done'


### PR DESCRIPTION
Observed repeated CI test failures running on aarch64-linux instances:
```
  > Failed test tests/100-lines
  > --- tests/100-lines.log      1970-01-01 00:00:01.000000000 +0000
  > +++ /build/tmp.Xnq7ZeMG7J/100-lines.log    2025-01-29 15:07:16.278776269 +0000
  > @@ -49,8 +49,8 @@
  >  line 25 to stdout
  >  line 25 to stderr
  >  line 26 to stdout
  > -line 26 to stderr
  >  line 27 to stdout
  > +line 26 to stderr
  >  line 27 to stderr
  >  line 28 to stdout
  >  line 28 to stderr
  > make: *** [Makefile:137: tests/100-lines/log] Error 1
```
This occurs when the kernel _actually_ delivers messages out of order to the stdout and stderr file descriptors, which is very much possible for the Linux kernel.

There's really no resolution for this apart from lowering our expectations, and this patch roughly triples the time spent sleeping between lines sent to stdout/stderr by changing `sleep 0` to `sleep 0.01`:
```
  $ time sleep 0
  real    0m0.003s
  user    0m0.004s
  sys     0m0.000s

  $ time sleep 0.01
  real    0m0.013s
  user    0m0.002s
  sys     0m0.001s
```