### PR TITLE
fix: increase sleep in midline-flush.c

### DIFF
--- a/tests/midline-flush.c
+++ b/tests/midline-flush.c
@@ -16,9 +16,9 @@ int main() {
     fflush(stdout);
     fflush(stderr);
     goodbye(stderr);
-    usleep(3); // It only takes a millisecond to give stderr a head start
-               // but we'll give it three to avoid false positives where
-	       // the first line is written to stdout.
+    usleep(30); // It only takes a millisecond to give stderr a head start
+                // but we'll give it thirty to avoid false positives where
+	        // the first line is written to stdout.
     goodbye(stdout);
     fflush(stderr);
     fflush(stdout);

--- a/tests/midline-flush.c
+++ b/tests/midline-flush.c
@@ -18,7 +18,7 @@ int main() {
     goodbye(stderr);
     usleep(30); // It only takes a millisecond to give stderr a head start
                 // but we'll give it thirty to avoid false positives where
-	        // the first line is written to stdout.
+                // the first line is written to stdout.
     goodbye(stdout);
     fflush(stderr);
     fflush(stdout);


### PR DESCRIPTION
Increasing sleep tenfold to really minimize the chances of test races at build time.