### PR TITLE
fix: move midline-flush.c sleep to occur between flush() invocations

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -39,9 +39,6 @@
     "build": {
       "t3": {
         "command": "  make\n  make test\n  make install PREFIX=$out\n",
-        "files": null,
-        "runtime-packages": null,
-        "systems": null,
         "sandbox": "pure"
       }
     }

--- a/tests/midline-flush.c
+++ b/tests/midline-flush.c
@@ -16,11 +16,13 @@ int main() {
     fflush(stdout);
     fflush(stderr);
     goodbye(stderr);
-    usleep(30); // It only takes a millisecond to give stderr a head start
-                // but we'll give it thirty to avoid false positives where
-                // the first line is written to stdout.
     goodbye(stdout);
     fflush(stderr);
+    usleep(10); // It only takes a millisecond to give stderr a head start
+                // but we'll give it ten to avoid false positives where the
+                // first line is written to stdout.
     fflush(stdout);
+    usleep(10); // Sleep once more to ensure that stdout has a chance to
+                // flush its buffer before the subsequent test runs.
     return 0;
 }


### PR DESCRIPTION
We were doing the sleep() invocation between writing to the stdout/err file descriptors rather than between the times we were flushing them. This update divides the time slept by 3 (bringing it to approx 3x what it was before we encountered CI failures), while moving the sleep between the two flush() invocations.

It also adds an extra sleep following the second flush() invocation to make sure that the kernel has time to communicate its contents before the subsequent test.