### PR TITLE
fix: add sleep to fibonacci test

### DIFF
--- a/tests/fibonacci.args
+++ b/tests/fibonacci.args
@@ -1,1 +1,1 @@
--- bash -c 'n=100; x=0; y=1; z=$x; function out() { if [ `expr $1 % 2` -eq 0 ]; then echo "$1: evens to stdout"; else echo "$1: odds to stderr" 1>&2; fi }; for i in `seq 1 $n`; do x=`expr $x + $y`; y=$z; z=$x; out $x; done'
+-- bash -c 'n=100; x=0; y=1; z=$x; function out() { if [ `expr $1 % 2` -eq 0 ]; then echo "$1: evens to stdout"; else echo "$1: odds to stderr" 1>&2; fi }; for i in `seq 1 $n`; do x=`expr $x + $y`; y=$z; z=$x; out $x; sleep 0.01; done'


### PR DESCRIPTION
I hadn't added a sleep to the fibonacci test previously because the delays added by the math being performed has always been sufficient to ensure that lines sent to stdout and stderr don't arrive out of order. But apparently the hydra.nixos.org build farm has faster machines because one managed to trip the race condition (once): https://hydra.nixos.org/build/290187717/log

Adding 10ms sleep to make it signficantly more likely that lines sent to stdout and stderr will arrive in the right order.