### PR TITLE
chore: improve error logging

### DIFF
--- a/t3.c
+++ b/t3.c
@@ -735,7 +735,8 @@ int main(int argc, char *argv[]) {
 
   FILE *logfile = fopen(logfile_name, "w");
   if (!logfile) {
-    perror("Error opening logfile");
+    fprintf(stderr, "Error opening logfile %s %s\n", logfile_name,
+            strerror(errno));
     return EXIT_FAILURE;
   }
 

--- a/t3.c
+++ b/t3.c
@@ -735,7 +735,7 @@ int main(int argc, char *argv[]) {
 
   FILE *logfile = fopen(logfile_name, "w");
   if (!logfile) {
-    fprintf(stderr, "Error opening logfile %s %s\n", logfile_name,
+    fprintf(stderr, "Error opening logfile '%s': %s\n", logfile_name,
             strerror(errno));
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
If we cannot open a log file, print its file name too. This is handy when a user skips the log filename accidently, e.g., runs t3 -- /bin/echo foo.