### PR TITLE
fix: improve midline-flush tests

### DIFF
--- a/tests/midline-flush.args
+++ b/tests/midline-flush.args
@@ -1,1 +1,1 @@
--- sh -c 'for i in `seq 1 10`; do tests/midline-flush; done'
+-- sh -c 'for i in `seq 1 10`; do tests/midline-flush $i; sleep 0.01; done'

--- a/tests/midline-flush.c
+++ b/tests/midline-flush.c
@@ -7,10 +7,10 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#define hello(fd) fprintf(fd, "Hello, %s! ", fd == stdout ? "stdout" : "stderr")
-#define goodbye(fd) fprintf(fd, "Goodbye, %s!\n", fd == stdout ? "stdout" : "stderr")
+#define hello(fd) fprintf(fd, "%s: Hello, %s! ", argv[1], fd == stdout ? "stdout" : "stderr")
+#define goodbye(fd) fprintf(fd, "%s: Goodbye, %s!\n", argv[1], fd == stdout ? "stdout" : "stderr")
 
-int main() {
+int main(int argc, char *argv[]) {
     hello(stdout);
     hello(stderr);
     fflush(stdout);

--- a/tests/midline-flush.err
+++ b/tests/midline-flush.err
@@ -1,10 +1,10 @@
-Hello, stderr! Goodbye, stderr!
-Hello, stderr! Goodbye, stderr!
-Hello, stderr! Goodbye, stderr!
-Hello, stderr! Goodbye, stderr!
-Hello, stderr! Goodbye, stderr!
-Hello, stderr! Goodbye, stderr!
-Hello, stderr! Goodbye, stderr!
-Hello, stderr! Goodbye, stderr!
-Hello, stderr! Goodbye, stderr!
-Hello, stderr! Goodbye, stderr!
+1: Hello, stderr! 1: Goodbye, stderr!
+2: Hello, stderr! 2: Goodbye, stderr!
+3: Hello, stderr! 3: Goodbye, stderr!
+4: Hello, stderr! 4: Goodbye, stderr!
+5: Hello, stderr! 5: Goodbye, stderr!
+6: Hello, stderr! 6: Goodbye, stderr!
+7: Hello, stderr! 7: Goodbye, stderr!
+8: Hello, stderr! 8: Goodbye, stderr!
+9: Hello, stderr! 9: Goodbye, stderr!
+10: Hello, stderr! 10: Goodbye, stderr!

--- a/tests/midline-flush.log
+++ b/tests/midline-flush.log
@@ -1,20 +1,20 @@
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
-[36m[0m[1m[33mHello, stderr! Goodbye, stderr![0m
-[36m[0mHello, stdout! Goodbye, stdout![0m
+[36m[0m[1m[33m1: Hello, stderr! 1: Goodbye, stderr![0m
+[36m[0m1: Hello, stdout! 1: Goodbye, stdout![0m
+[36m[0m[1m[33m2: Hello, stderr! 2: Goodbye, stderr![0m
+[36m[0m2: Hello, stdout! 2: Goodbye, stdout![0m
+[36m[0m[1m[33m3: Hello, stderr! 3: Goodbye, stderr![0m
+[36m[0m3: Hello, stdout! 3: Goodbye, stdout![0m
+[36m[0m[1m[33m4: Hello, stderr! 4: Goodbye, stderr![0m
+[36m[0m4: Hello, stdout! 4: Goodbye, stdout![0m
+[36m[0m[1m[33m5: Hello, stderr! 5: Goodbye, stderr![0m
+[36m[0m5: Hello, stdout! 5: Goodbye, stdout![0m
+[36m[0m[1m[33m6: Hello, stderr! 6: Goodbye, stderr![0m
+[36m[0m6: Hello, stdout! 6: Goodbye, stdout![0m
+[36m[0m[1m[33m7: Hello, stderr! 7: Goodbye, stderr![0m
+[36m[0m7: Hello, stdout! 7: Goodbye, stdout![0m
+[36m[0m[1m[33m8: Hello, stderr! 8: Goodbye, stderr![0m
+[36m[0m8: Hello, stdout! 8: Goodbye, stdout![0m
+[36m[0m[1m[33m9: Hello, stderr! 9: Goodbye, stderr![0m
+[36m[0m9: Hello, stdout! 9: Goodbye, stdout![0m
+[36m[0m[1m[33m10: Hello, stderr! 10: Goodbye, stderr![0m
+[36m[0m10: Hello, stdout! 10: Goodbye, stdout![0m

--- a/tests/midline-flush.out
+++ b/tests/midline-flush.out
@@ -1,10 +1,10 @@
-Hello, stdout! Goodbye, stdout!
-Hello, stdout! Goodbye, stdout!
-Hello, stdout! Goodbye, stdout!
-Hello, stdout! Goodbye, stdout!
-Hello, stdout! Goodbye, stdout!
-Hello, stdout! Goodbye, stdout!
-Hello, stdout! Goodbye, stdout!
-Hello, stdout! Goodbye, stdout!
-Hello, stdout! Goodbye, stdout!
-Hello, stdout! Goodbye, stdout!
+1: Hello, stdout! 1: Goodbye, stdout!
+2: Hello, stdout! 2: Goodbye, stdout!
+3: Hello, stdout! 3: Goodbye, stdout!
+4: Hello, stdout! 4: Goodbye, stdout!
+5: Hello, stdout! 5: Goodbye, stdout!
+6: Hello, stdout! 6: Goodbye, stdout!
+7: Hello, stdout! 7: Goodbye, stdout!
+8: Hello, stdout! 8: Goodbye, stdout!
+9: Hello, stdout! 9: Goodbye, stdout!
+10: Hello, stdout! 10: Goodbye, stdout!


### PR DESCRIPTION
Observed failed tests for the aarch64-linux build job on hydra.nixos.org:
- https://hydra.nixos.org/build/292893102/nixlog/1

I'm confident the `usleep()` statements within `midline-flush.c` handles ordering within a single invocation, but the test does demonstrate that it must be possible to schedule overlapping program invocations, where the first flush of a subsequent invocation can be processed in advance of the final flush from a preceding one.

This update adds a numeric identifier to each `hello()` and `goodbye()` statement, which should help to identify exactly which invocation gets out of order, and also adds a sleep in the main shell loop to make it that much less likely that this race will occur.